### PR TITLE
add back the "application/xml" content-type

### DIFF
--- a/ckanext/qa/tasks.py
+++ b/ckanext/qa/tasks.py
@@ -36,6 +36,7 @@ MIME_TYPE_SCORE = {
     'xls': 2,
     'text/csv': 3,
     'application/json': 3,
+    'application/xml': 3,
     'text/xml': 3,
     'csv': 3,
     'xml': 3,


### PR DESCRIPTION
I think it was accidentally removed on commit okfn/ckanext-qa@c6d3199 when fixing xml openness value.
This is a small fix but quite important, given that CKAN itself serves XML files with the "application/xml" content-type!
