### PR TITLE
change resource_read.html template extension to enable display of QA rating

### DIFF
--- a/ckanext/qa/templates_extend/package/resource_read.html
+++ b/ckanext/qa/templates_extend/package/resource_read.html
@@ -1,6 +1,6 @@
 {% ckan_extends %}
 
-{% block resource_information %}
+{% block resource_additional_information %}
   {{ super() }}
 
   {{ h.qa_stars(c.resource.id) }}


### PR DESCRIPTION
Will automatically display QA rating at the resource level once the extension is activated.
