### PR TITLE
"package_id" is valid field of resource, not "package"

### DIFF
--- a/ckanext/qa/tasks.py
+++ b/ckanext/qa/tasks.py
@@ -119,7 +119,7 @@ def update(context, data):
 
         result = resource_score(context, data)
         log.info('Openness score for dataset %s (res#%s): %r (%s)',
-                 data['package'], data['position'],
+                 data['package_id'], data['position'],
                  result['openness_score'], result['openness_score_reason'])
         
         task_status_data = _task_status_data(data['id'], result)


### PR DESCRIPTION
Resolving #13 for CKAN 2.3