### PR TITLE
Enhancements from Queensland Government fork

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,20 @@
+[flake8]
+# @see https://flake8.pycqa.org/en/latest/user/configuration.html?highlight=.flake8
+
+exclude =
+    ckan
+    scripts
+
+# Extended output format.
+format = pylint
+
+# Show the source of errors.
+show_source = True
+
+max-complexity = 10
+
+# List ignore rules one per line.
+ignore =
+    E501
+    C901
+    W503

--- a/ckanext/qa/bin/common.py
+++ b/ckanext/qa/bin/common.py
@@ -48,5 +48,5 @@ def get_resources(state='active', publisher_ref=None, resource_id=None, dataset_
         resources = resources.filter(model.Resource.id == resource_id)
         criteria.append('Resource:%s' % resource_id)
     resources = resources.all()
-    print '%i resources (%s)' % (len(resources), ' '.join(criteria))
+    print('%i resources (%s)' % (len(resources), ' '.join(criteria)))
     return resources

--- a/ckanext/qa/bin/migrate_task_status.py
+++ b/ckanext/qa/bin/migrate_task_status.py
@@ -12,7 +12,6 @@ import json
 import datetime
 
 import common
-import pytz
 from running_stats import StatsList
 
 # pip install 'ProgressBar==2.3'
@@ -20,7 +19,7 @@ from progressbar import ProgressBar, Percentage, Bar, ETA
 
 START_OF_TIME = datetime.datetime(1980, 1, 1)
 END_OF_TIME = datetime.datetime(9999, 12, 31)
-TODAY = datetime.datetime.now(tz=pytz.utc)
+TODAY = datetime.datetime.utcnow()
 
 # NB put no CKAN imports here, or logging breaks
 

--- a/ckanext/qa/bin/migrate_task_status.py
+++ b/ckanext/qa/bin/migrate_task_status.py
@@ -20,7 +20,7 @@ from progressbar import ProgressBar, Percentage, Bar, ETA
 
 START_OF_TIME = datetime.datetime(1980, 1, 1)
 END_OF_TIME = datetime.datetime(9999, 12, 31)
-TODAY = datetime.datetime.now(tzinfo=pytz.utc)
+TODAY = datetime.datetime.now(tz=pytz.utc)
 
 # NB put no CKAN imports here, or logging breaks
 

--- a/ckanext/qa/bin/migrate_task_status.py
+++ b/ckanext/qa/bin/migrate_task_status.py
@@ -12,6 +12,7 @@ import json
 import datetime
 
 import common
+import pytz
 from running_stats import StatsList
 
 # pip install 'ProgressBar==2.3'
@@ -19,7 +20,7 @@ from progressbar import ProgressBar, Percentage, Bar, ETA
 
 START_OF_TIME = datetime.datetime(1980, 1, 1)
 END_OF_TIME = datetime.datetime(9999, 12, 31)
-TODAY = datetime.datetime.now()
+TODAY = datetime.datetime.now(tzinfo=pytz.utc)
 
 # NB put no CKAN imports here, or logging breaks
 

--- a/ckanext/qa/bin/migrate_task_status.py
+++ b/ckanext/qa/bin/migrate_task_status.py
@@ -59,7 +59,7 @@ def migrate(options):
         # time, so some timezone nonesense going on. Can't do much.
         archival = Archival.get_for_resource(res.id)
         if not archival:
-            print add_stat('QA but no Archival data', res, stats)
+            print(add_stat('QA but no Archival data', res, stats))
             continue
         archival_date = archival.updated
         # the state of the resource was as it was archived on the date of
@@ -112,10 +112,10 @@ def migrate(options):
                 model.Session.add(qa)
             add_stat('Added to QA table', res, stats)
 
-    print 'Summary\n', stats.report()
+    print('Summary\n', stats.report())
     if options.write:
         model.repo.commit_and_remove()
-        print 'Written'
+        print('Written')
 
 
 def add_stat(outcome, res, stats, extra_info=None):
@@ -154,10 +154,10 @@ if __name__ == '__main__':
     if len(args) != 1:
         parser.error('Wrong number of arguments (%i)' % len(args))
     config_ini = args[0]
-    print 'Loading CKAN config...'
+    print('Loading CKAN config...')
     common.load_config(config_ini)
     common.register_translator()
-    print 'Done'
+    print('Done')
     # Setup logging to print debug out for local only
     rootLogger = logging.getLogger()
     rootLogger.setLevel(logging.WARNING)

--- a/ckanext/qa/bin/running_stats.py
+++ b/ckanext/qa/bin/running_stats.py
@@ -14,7 +14,7 @@ for package in packages:
         package_stats.increment('deleted')
     else:
         package_stats.increment('not deleted')
-print package_stats.report()
+print(package_stats.report())
 > deleted: 30
 > not deleted: 70
 
@@ -26,7 +26,7 @@ for package in packages:
         package_stats.add('deleted', package.name)
     else:
         package_stats.add('not deleted' package.name)
-print package_stats.report()
+print(package_stats.report())
 > deleted: 30 pollution-uk, flood-regions, river-quality, ...
 > not deleted: 70 spending-bristol, ...
 
@@ -34,6 +34,7 @@ print package_stats.report()
 
 import copy
 import datetime
+
 
 class StatsCount(dict):
     # {category:count}
@@ -109,6 +110,6 @@ if __name__ == '__main__':
     package_stats.add('Success', 'good3')
     package_stats.add('Success', 'good4')
     package_stats.add('Failure', 'bad1')
-    print package_stats.report()
+    print(package_stats.report())
 
-    print StatsList().report()
+    print(StatsList().report())

--- a/ckanext/qa/bin/running_stats.py
+++ b/ckanext/qa/bin/running_stats.py
@@ -35,16 +35,13 @@ print package_stats.report()
 import copy
 import datetime
 
-import pytz
-
-
 class StatsCount(dict):
     # {category:count}
     _init_value = 0
     report_value_limit = 150
 
     def __init__(self, *args, **kwargs):
-        self._start_time = datetime.datetime.now(tz=pytz.utc)
+        self._start_time = datetime.datetime.utcnow()
         super(StatsCount, self).__init__(*args, **kwargs)
 
     def _init_category(self, category):
@@ -82,7 +79,7 @@ class StatsCount(dict):
             lines = [indent_str + 'None']
 
         if show_time_taken:
-            time_taken = datetime.datetime.now(tz=pytz.utc) - self._start_time
+            time_taken = datetime.datetime.utcnow() - self._start_time
             lines.append(indent_str + 'Time taken (h:m:s): %s' % time_taken)
         return '\n'.join(lines)
 

--- a/ckanext/qa/bin/running_stats.py
+++ b/ckanext/qa/bin/running_stats.py
@@ -44,7 +44,7 @@ class StatsCount(dict):
     report_value_limit = 150
 
     def __init__(self, *args, **kwargs):
-        self._start_time = datetime.datetime.now(tzinfo=pytz.utc)
+        self._start_time = datetime.datetime.now(tz=pytz.utc)
         super(StatsCount, self).__init__(*args, **kwargs)
 
     def _init_category(self, category):
@@ -82,7 +82,7 @@ class StatsCount(dict):
             lines = [indent_str + 'None']
 
         if show_time_taken:
-            time_taken = datetime.datetime.now(tzinfo=pytz.utc) - self._start_time
+            time_taken = datetime.datetime.now(tz=pytz.utc) - self._start_time
             lines.append(indent_str + 'Time taken (h:m:s): %s' % time_taken)
         return '\n'.join(lines)
 

--- a/ckanext/qa/bin/running_stats.py
+++ b/ckanext/qa/bin/running_stats.py
@@ -35,6 +35,8 @@ print package_stats.report()
 import copy
 import datetime
 
+import pytz
+
 
 class StatsCount(dict):
     # {category:count}
@@ -42,7 +44,7 @@ class StatsCount(dict):
     report_value_limit = 150
 
     def __init__(self, *args, **kwargs):
-        self._start_time = datetime.datetime.now()
+        self._start_time = datetime.datetime.now(tzinfo=pytz.utc)
         super(StatsCount, self).__init__(*args, **kwargs)
 
     def _init_category(self, category):
@@ -80,7 +82,7 @@ class StatsCount(dict):
             lines = [indent_str + 'None']
 
         if show_time_taken:
-            time_taken = datetime.datetime.now() - self._start_time
+            time_taken = datetime.datetime.now(tzinfo=pytz.utc) - self._start_time
             lines.append(indent_str + 'Time taken (h:m:s): %s' % time_taken)
         return '\n'.join(lines)
 

--- a/ckanext/qa/commands.py
+++ b/ckanext/qa/commands.py
@@ -1,4 +1,5 @@
 import logging
+import six
 import sys
 
 from sqlalchemy import or_
@@ -65,7 +66,7 @@ class QACommand(p.toolkit.CkanCommand):
         Parse command line arguments and call appropriate method.
         """
         if not self.args or self.args[0] in ['--help', '-h', 'help']:
-            print QACommand.__doc__
+            print(QACommand.__doc__)
             return
 
         cmd = self.args[0]
@@ -177,44 +178,44 @@ class QACommand(p.toolkit.CkanCommand):
         from ckanext.qa.sniff_format import sniff_file_format
 
         if len(self.args) < 2:
-            print 'Not enough arguments', self.args
+            print('Not enough arguments', self.args)
             sys.exit(1)
         for filepath in self.args[1:]:
             format_ = sniff_file_format(
                 filepath, logging.getLogger('ckanext.qa.sniffer'))
             if format_:
-                print 'Detected as: %s - %s' % (format_['display_name'],
-                                                filepath)
+                print('Detected as: %s - %s' % (format_['display_name'],
+                                                filepath))
             else:
-                print 'ERROR: Could not recognise format of: %s' % filepath
+                print('ERROR: Could not recognise format of: %s' % filepath)
 
     def view(self, package_ref=None):
         from ckan import model
 
         q = model.Session.query(model.TaskStatus).filter_by(task_type='qa')
-        print 'QA records - %i TaskStatus rows' % q.count()
-        print '      across %i Resources' % q.distinct('entity_id').count()
+        print('QA records - %i TaskStatus rows' % q.count())
+        print('      across %i Resources' % q.distinct('entity_id').count())
 
         if package_ref:
             pkg = model.Package.get(package_ref)
-            print 'Package %s %s' % (pkg.name, pkg.id)
+            print('Package %s %s' % (pkg.name, pkg.id))
             for res in pkg.resources:
-                print 'Resource %s' % res.id
+                print('Resource %s' % res.id)
                 for row in q.filter_by(entity_id=res.id):
-                    print '* %s = %r error=%r' % (row.key, row.value,
-                                                  row.error)
+                    print('* %s = %r error=%r' % (row.key, row.value,
+                                                  row.error))
 
     def clean(self):
         from ckan import model
 
-        print 'Before:'
+        print('Before:')
         self.view()
 
         q = model.Session.query(model.TaskStatus).filter_by(task_type='qa')
         q.delete()
         model.Session.commit()
 
-        print 'After:'
+        print('After:')
         self.view()
 
     def migrate1(self):
@@ -223,32 +224,32 @@ class QACommand(p.toolkit.CkanCommand):
         q_status = model.Session.query(model.TaskStatus) \
             .filter_by(task_type='qa') \
             .filter_by(key='status')
-        print '* %s with "status" will be deleted e.g. %s' % (q_status.count(),
-                                                              q_status.first())
+        print('* %s with "status" will be deleted e.g. %s' % (q_status.count(),
+                                                              q_status.first()))
         q_failures = model.Session.query(model.TaskStatus) \
             .filter_by(task_type='qa') \
             .filter_by(key='openness_score_failure_count')
-        print '* %s with openness_score_failure_count to be deleted e.g.\n%s'\
-            % (q_failures.count(), q_failures.first())
+        print('* %s with openness_score_failure_count to be deleted e.g.\n%s'
+              % (q_failures.count(), q_failures.first()))
         q_score = model.Session.query(model.TaskStatus) \
             .filter_by(task_type='qa') \
             .filter_by(key='openness_score')
-        print '* %s with openness_score to migrate e.g.\n%s' % \
-            (q_score.count(), q_score.first())
+        print('* %s with openness_score to migrate e.g.\n%s' %
+              (q_score.count(), q_score.first()))
         q_reason = model.Session.query(model.TaskStatus) \
             .filter_by(task_type='qa') \
             .filter_by(key='openness_score_reason')
-        print '* %s with openness_score_reason to migrate e.g.\n%s' % \
-            (q_reason.count(), q_reason.first())
-        raw_input('Press Enter to continue')
+        print('* %s with openness_score_reason to migrate e.g.\n%s' %
+              (q_reason.count(), q_reason.first()))
+        six.input('Press Enter to continue')
 
         q_status.delete()
         model.Session.commit()
-        print '..."status" deleted'
+        print('..."status" deleted')
 
         q_failures.delete()
         model.Session.commit()
-        print '..."openness_score_failure_count" deleted'
+        print('..."openness_score_failure_count" deleted')
 
         for task_status in q_score:
             reason_task_status = q_reason \
@@ -265,15 +266,15 @@ class QACommand(p.toolkit.CkanCommand):
                 'reason': reason,
                 'format': None,
                 'is_broken': None,
-                })
+            })
             model.Session.commit()
-        print '..."openness_score" and "openness_score_reason" migrated'
+        print('..."openness_score" and "openness_score_reason" migrated')
 
         count = q_reason.count()
         q_reason.delete()
         model.Session.commit()
-        print '... %i remaining "openness_score_reason" deleted' % count
+        print('... %i remaining "openness_score_reason" deleted' % count)
 
         model.Session.flush()
         model.Session.remove()
-        print 'Migration succeeded'
+        print('Migration succeeded')

--- a/ckanext/qa/controllers.py
+++ b/ckanext/qa/controllers.py
@@ -102,7 +102,7 @@ class LinkCheckerController(BaseController):
             result['mimetype'] = self._extract_mimetype(headers)
             result['size'] = headers.get('content-length', '')
             result['last_modified'] = self._parse_and_format_date(headers.get('last-modified', ''))
-        except LinkCheckerError, e:
+        except LinkCheckerError as e:
             result['url_errors'].append(str(e))
         return result
 

--- a/ckanext/qa/lib.py
+++ b/ckanext/qa/lib.py
@@ -55,7 +55,7 @@ def resource_format_scores():
         with open(json_filepath) as format_file:
             try:
                 file_resource_formats = json.loads(format_file.read())
-            except ValueError, e:
+            except ValueError as e:
                 # includes simplejson.decoder.JSONDecodeError
                 raise ValueError('Invalid JSON syntax in %s: %s' %
                                  (json_filepath, e))
@@ -90,7 +90,7 @@ def create_qa_update_package_task(package, queue):
     from pylons import config
     ckan_ini_filepath = os.path.abspath(config.__file__)
 
-    compat_enqueue('qa.update_package', tasks.update_package, queue,  args=[ckan_ini_filepath, package.id])
+    compat_enqueue('qa.update_package', tasks.update_package, queue, args=[ckan_ini_filepath, package.id])
     log.debug('QA of package put into celery queue %s: %s',
               queue, package.name)
 

--- a/ckanext/qa/logic/action.py
+++ b/ckanext/qa/logic/action.py
@@ -30,7 +30,7 @@ def qa_resource_show(context, data_dict):
         'name': pkg.name,
         'title': pkg.title,
         'id': res.id
-        }
+    }
     return_dict['archival'] = archival.as_dict()
     return_dict.update(qa.as_dict())
     return return_dict

--- a/ckanext/qa/model.py
+++ b/ckanext/qa/model.py
@@ -1,5 +1,6 @@
 import uuid
 import datetime
+import six
 
 from sqlalchemy import Column
 from sqlalchemy import types
@@ -15,7 +16,7 @@ Base = declarative_base()
 
 
 def make_uuid():
-    return unicode(uuid.uuid4())
+    return six.text_type(uuid.uuid4())
 
 
 class QA(Base):
@@ -40,7 +41,7 @@ class QA(Base):
 
     def __repr__(self):
         summary = 'score=%s format=%s' % (self.openness_score, self.format)
-        details = unicode(self.openness_score_reason).encode('unicode_escape')
+        details = six.text_type(self.openness_score_reason).encode('unicode_escape')
         package = model.Package.get(self.package_id)
         package_name = package.name if package else '?%s?' % self.package_id
         return '<QA %s /dataset/%s/resource/%s %s>' % \

--- a/ckanext/qa/model.py
+++ b/ckanext/qa/model.py
@@ -1,6 +1,7 @@
 import uuid
 import datetime
 
+import pytz
 from sqlalchemy import Column
 from sqlalchemy import types
 from sqlalchemy.ext.declarative import declarative_base
@@ -35,8 +36,8 @@ class QA(Base):
     openness_score_reason = Column(types.UnicodeText)
     format = Column(types.UnicodeText)
 
-    created = Column(types.DateTime, default=datetime.datetime.now)
-    updated = Column(types.DateTime, default=datetime.datetime.now)
+    created = Column(types.DateTime, default=datetime.datetime.now(tzinfo=pytz.utc))
+    updated = Column(types.DateTime, default=datetime.datetime.now(tzinfo=pytz.utc))
 
     def __repr__(self):
         summary = 'score=%s format=%s' % (self.openness_score, self.format)

--- a/ckanext/qa/model.py
+++ b/ckanext/qa/model.py
@@ -1,7 +1,6 @@
 import uuid
 import datetime
 
-import pytz
 from sqlalchemy import Column
 from sqlalchemy import types
 from sqlalchemy.ext.declarative import declarative_base
@@ -36,8 +35,8 @@ class QA(Base):
     openness_score_reason = Column(types.UnicodeText)
     format = Column(types.UnicodeText)
 
-    created = Column(types.DateTime, default=datetime.datetime.now(tzinfo=pytz.utc))
-    updated = Column(types.DateTime, default=datetime.datetime.now(tzinfo=pytz.utc))
+    created = Column(types.DateTime, default=datetime.datetime.utcnow)
+    updated = Column(types.DateTime, default=datetime.datetime.utcnow)
 
     def __repr__(self):
         summary = 'score=%s format=%s' % (self.openness_score, self.format)

--- a/ckanext/qa/plugin.py
+++ b/ckanext/qa/plugin.py
@@ -67,7 +67,7 @@ class QAPlugin(p.SingletonPlugin, p.toolkit.DefaultDatasetForm):
         return {
             'qa_resource_show': action.qa_resource_show,
             'qa_package_openness_show': action.qa_package_openness_show,
-            }
+        }
 
     # IAuthFunctions
 
@@ -75,7 +75,7 @@ class QAPlugin(p.SingletonPlugin, p.toolkit.DefaultDatasetForm):
         return {
             'qa_resource_show': auth.qa_resource_show,
             'qa_package_openness_show': auth.qa_package_openness_show,
-            }
+        }
 
     # ITemplateHelpers
 
@@ -85,7 +85,7 @@ class QAPlugin(p.SingletonPlugin, p.toolkit.DefaultDatasetForm):
             helpers.qa_openness_stars_resource_html,
             'qa_openness_stars_dataset_html':
             helpers.qa_openness_stars_dataset_html,
-            }
+        }
 
     # IPackageController
 

--- a/ckanext/qa/reports.py
+++ b/ckanext/qa/reports.py
@@ -72,7 +72,7 @@ def openness_index(include_sub_organizations=False):
 
     table = []
     for org_name, org_counts in results.iteritems():
-        total_stars = sum([k*v for k, v in org_counts['score_counts'].items() if k])
+        total_stars = sum([k * v for k, v in org_counts['score_counts'].items() if k])
         num_pkgs_scored = sum([v for k, v in org_counts['score_counts'].items()
                               if k is not None])
         average_stars = round(float(total_stars) / num_pkgs_scored, 1) \
@@ -82,7 +82,7 @@ def openness_index(include_sub_organizations=False):
             ('organization_name', org_name),
             ('total_stars', total_stars),
             ('average_stars', average_stars),
-            ))
+        ))
         row.update(jsonify_counter(org_counts['score_counts']))
         table.append(row)
 
@@ -136,10 +136,10 @@ def openness_for_organization(organization=None, include_sub_organizations=False
                 ('organization_title', org.title),
                 ('openness_score', qa['openness_score']),
                 ('openness_score_reason', qa['openness_score_reason']),
-                )))
+            )))
             score_counts[qa['openness_score']] += 1
 
-    total_stars = sum([k*v for k, v in score_counts.items() if k])
+    total_stars = sum([k * v for k, v in score_counts.items() if k])
     num_pkgs_with_stars = sum([v for k, v in score_counts.items()
                                if k is not None])
     average_stars = round(float(total_stars) / num_pkgs_with_stars, 1) \
@@ -172,7 +172,7 @@ openness_report_info = {
     'option_combinations': openness_report_combinations,
     'generate': openness_report,
     'template': 'report/openness.html',
-    }
+}
 
 
 def jsonify_counter(counter):

--- a/ckanext/qa/sniff_format.py
+++ b/ckanext/qa/sniff_format.py
@@ -124,7 +124,7 @@ def sniff_file_format(filepath):
                 if has_rdfa(buf):
                     format_ = {'format': 'RDFa'}
 
-    else:
+    if not format_:
         # Excel files sometimes not picked up by magic, so try alternative
         if is_excel(filepath):
             format_ = {'format': 'XLS'}

--- a/ckanext/qa/sniff_format.py
+++ b/ckanext/qa/sniff_format.py
@@ -36,7 +36,7 @@ def sniff_file_format(filepath):
     '''
     format_ = None
     log.info('Sniffing file format of: %s', filepath)
-    filepath_utf8 = filepath.encode('utf8') if isinstance(filepath, six.text_types) \
+    filepath_utf8 = filepath.encode('utf8') if isinstance(filepath, six.string_types) \
         else filepath
     mime_type = magic.from_file(filepath_utf8, mime=True)
     log.info('Magic detects file as: %s', mime_type)

--- a/ckanext/qa/sniff_format.py
+++ b/ckanext/qa/sniff_format.py
@@ -1,7 +1,9 @@
+# encoding: utf-8
 import re
 import zipfile
 import os
 from collections import defaultdict
+import six
 import subprocess
 import StringIO
 
@@ -15,6 +17,7 @@ from ckan.lib import helpers as ckan_helpers
 import logging
 
 log = logging.getLogger(__name__)
+
 
 def sniff_file_format(filepath):
     '''For a given filepath, work out what file format it is.
@@ -33,12 +36,13 @@ def sniff_file_format(filepath):
     '''
     format_ = None
     log.info('Sniffing file format of: %s', filepath)
-    filepath_utf8 = filepath.encode('utf8') if isinstance(filepath, unicode) \
+    filepath_utf8 = filepath.encode('utf8') if isinstance(filepath, six.text_types) \
         else filepath
     mime_type = magic.from_file(filepath_utf8, mime=True)
     log.info('Magic detects file as: %s', mime_type)
     if mime_type:
-        if mime_type == 'application/xml':
+        # some operating systems magic mime xml as text/xml
+        if mime_type == 'application/xml' or mime_type == 'text/xml':
             with open(filepath) as f:
                 buf = f.read(5000)
             format_ = get_xml_variant_including_xml_declaration(buf)
@@ -139,14 +143,14 @@ def is_json(buf):
     JSON format.'''
     string = '"[^"]*"'
     string_re = re.compile(string)
-    number_re = re.compile('-?\d+(\.\d+)?([eE][+-]?\d+)?')
-    extra_values_re = re.compile('true|false|null')
-    object_start_re = re.compile('{%s:\s?' % string)
-    object_middle_re = re.compile('%s:\s?' % string)
-    object_end_re = re.compile('}')
-    comma_re = re.compile(',\s?')
-    array_start_re = re.compile('\[')
-    array_end_re = re.compile('\]')
+    number_re = re.compile(r'-?\d+(\.\d+)?([eE][+-]?\d+)?')
+    extra_values_re = re.compile(r'true|false|null')
+    object_start_re = re.compile(r'{%s:\s?' % string)
+    object_middle_re = re.compile(r'%s:\s?' % string)
+    object_end_re = re.compile(r'}')
+    comma_re = re.compile(r',\s?')
+    array_start_re = re.compile(r'\[')
+    array_end_re = re.compile(r'\]')
     any_value_regexs = [string_re, number_re, object_start_re, array_start_re, extra_values_re]
 
     # simplified state machine - just looks at stack of object/array and
@@ -256,7 +260,7 @@ def _is_spreadsheet(table_set, format):
 
 def is_html(buf):
     '''If this buffer is HTML, return that format type, else None.'''
-    xml_re = '.{0,3}\s*(<\?xml[^>]*>\s*)?(<!doctype[^>]*>\s*)?<html[^>]*>'
+    xml_re = r'.{0,3}\s*(<\?xml[^>]*>\s*)?(<!doctype[^>]*>\s*)?<html[^>]*>'
     match = re.match(xml_re, buf, re.IGNORECASE)
     if match:
         log.info('HTML tag detected')
@@ -266,7 +270,7 @@ def is_html(buf):
 
 def is_iati(buf):
     '''If this buffer is IATI format, return that format type, else None.'''
-    xml_re = '.{0,3}\s*(<\?xml[^>]*>\s*)?(<!doctype[^>]*>\s*)?<iati-(activities|organisations)[^>]*>'
+    xml_re = r'.{0,3}\s*(<\?xml[^>]*>\s*)?(<!doctype[^>]*>\s*)?<iati-(activities|organisations)[^>]*>'
     match = re.match(xml_re, buf, re.IGNORECASE)
     if match:
         log.info('IATI tag detected')
@@ -277,13 +281,13 @@ def is_iati(buf):
 def is_xml_but_without_declaration(buf):
     '''Decides if this is a buffer of XML, but missing the usual <?xml ...?>
     tag.'''
-    xml_re = '.{0,3}\s*(<\?xml[^>]*>\s*)?(<!doctype[^>]*>\s*)?<([^>\s]*)([^>]*)>'
+    xml_re = r'.{0,3}\s*(<\?xml[^>]*>\s*)?(<!doctype[^>]*>\s*)?<([^>\s]*)([^>]*)>'
     match = re.match(xml_re, buf, re.IGNORECASE)
     if match:
         top_level_tag_name, top_level_tag_attributes = match.groups()[-2:]
-        if 'xmlns:' not in top_level_tag_attributes and \
-            (len(top_level_tag_name) > 20 or
-             len(top_level_tag_attributes) > 200):
+        if ('xmlns:' not in top_level_tag_attributes
+                and (len(top_level_tag_name) > 20
+                     or len(top_level_tag_attributes) > 200)):
             log.debug('Not XML (without declaration) - unlikely length first tag: <%s %s>',
                       top_level_tag_name, top_level_tag_attributes)
             return False
@@ -318,9 +322,9 @@ def get_xml_variant_without_xml_declaration(buf):
     p.StartElementHandler = start_element
     try:
         p.Parse(buf)
-    except GotFirstTag, e:
-        top_level_tag_name = str(e).lower()
-    except xml.sax.SAXException, e:
+    except GotFirstTag as e:
+        top_level_tag_name = six.text_type(e).lower()
+    except xml.sax.SAXException as e:
         log.info('Sax parse error: %s %s', e, buf)
         return {'format': 'XML'}
 
@@ -354,8 +358,8 @@ def has_rdfa(buf):
         return False
 
     # more rigorous check for them as tag attributes
-    about_re = '<[^>]+\sabout="[^"]+"[^>]*>'
-    property_re = '<[^>]+\sproperty="[^"]+"[^>]*>'
+    about_re = r'<[^>]+\sabout="[^"]+"[^>]*>'
+    property_re = r'<[^>]+\sproperty="[^"]+"[^>]*>'
     # remove CR to catch tags spanning more than one line
     # buf = re.sub('\r\n', ' ', buf)
     if not re.search(about_re, buf):
@@ -381,11 +385,11 @@ def get_zipped_format(filepath):
             filepaths = zip.namelist()
         finally:
             zip.close()
-    except zipfile.BadZipfile, e:
+    except zipfile.BadZipfile as e:
         log.info('Zip file open raised error %s: %s',
                  e, e.args)
         return
-    except Exception, e:
+    except Exception as e:
         log.warning('Zip file open raised exception %s: %s',
                     e, e.args)
         return
@@ -438,7 +442,7 @@ def get_zipped_format(filepath):
 def is_excel(filepath):
     try:
         xlrd.open_workbook(filepath)
-    except Exception, e:
+    except Exception as e:
         log.info('Not Excel - failed to load: %s %s', e, e.args)
         return False
     else:
@@ -534,12 +538,12 @@ def turtle_regex():
     '''
     global turtle_regex_
     if not turtle_regex_:
-        rdf_term = '(<[^ >]+>|_:\S+|".+?"(@\w+)?(\^\^\S+)?|\'.+?\'(@\w+)?(\^\^\S+)?|""".+?"""(@\w+)' \
-                   '?(\^\^\S+)?|\'\'\'.+?\'\'\'(@\w+)?(\^\^\S+)?|[+-]?([0-9]+|[0-9]*\.[0-9]+)(E[+-]?[0-9]+)?|false|true)'
+        rdf_term = r'(<[^ >]+>|_:\S+|".+?"(@\w+)?(\^\^\S+)?|\'.+?\'(@\w+)?(\^\^\S+)?|""".+?"""(@\w+)' \
+                   r'?(\^\^\S+)?|\'\'\'.+?\'\'\'(@\w+)?(\^\^\S+)?|[+-]?([0-9]+|[0-9]*\.[0-9]+)(E[+-]?[0-9]+)?|false|true)'
 
         # simple case is: triple_re = '^T T T \.$'.replace('T', rdf_term)
         # but extend to deal with multiple predicate-objects:
         # triple = '^T T T\s*(;\s*T T\s*)*\.\s*$'.replace('T', rdf_term).replace(' ', '\s+')
-        triple = '(^T|;)\s*T T\s*(;|\.\s*$)'.replace('T', rdf_term).replace(' ', '\s+')
+        triple = r'(^T|;)\s*T T\s*(;|\.\s*$)'.replace('T', rdf_term).replace(' ', r'\s+')
         turtle_regex_ = re.compile(triple, re.MULTILINE)
     return turtle_regex_

--- a/ckanext/qa/tasks.py
+++ b/ckanext/qa/tasks.py
@@ -442,9 +442,8 @@ def _download_url(url):
         tmp_file.close()
         os.remove(tmp_file.name)
         raise requests.exceptions.HTTPError(
-            "Received a bad HTTP response when trying to download the data file",
-            status_code=error.response.status_code,
-            request_url=url, response=error)
+            url, error.response.status_code,
+            "Received a bad HTTP response when trying to download the data file")
     except requests.exceptions.Timeout:
         log.warning('URL time out after {0}s'.format(DOWNLOAD_TIMEOUT))
         tmp_file.close()
@@ -459,9 +458,7 @@ def _download_url(url):
         log.warning('URL error: {}'.format(err_message))
         tmp_file.close()
         os.remove(tmp_file.name)
-        raise requests.exceptions.HTTPError(
-            message=err_message, status_code=None,
-            request_url=url, response=None)
+        raise requests.exceptions.HTTPError(url, None, err_message)
 
     log.info('Downloaded ok - %s', printable_file_size(length))
     tmp_file.seek(0)

--- a/ckanext/qa/tasks.py
+++ b/ckanext/qa/tasks.py
@@ -10,7 +10,6 @@ import tempfile
 import time
 import traceback
 
-import pytz
 import urlparse
 import routes
 
@@ -608,7 +607,7 @@ def save_qa_result(resource, qa_result):
     import ckan.model as model
     from ckanext.qa.model import QA
 
-    now = datetime.datetime.now(tz=pytz.utc)
+    now = datetime.datetime.utcnow()
 
     qa = QA.get_for_resource(resource.id)
     if not qa:

--- a/ckanext/qa/tasks.py
+++ b/ckanext/qa/tasks.py
@@ -442,8 +442,9 @@ def _download_url(url):
         tmp_file.close()
         os.remove(tmp_file.name)
         raise requests.exceptions.HTTPError(
-            url, error.response.status_code,
-            "Received a bad HTTP response when trying to download the data file")
+            error.response.status_code,
+            "Received a bad HTTP response when trying to download the data file",
+            url)
     except requests.exceptions.Timeout:
         log.warning('URL time out after {0}s'.format(DOWNLOAD_TIMEOUT))
         tmp_file.close()
@@ -458,7 +459,7 @@ def _download_url(url):
         log.warning('URL error: {}'.format(err_message))
         tmp_file.close()
         os.remove(tmp_file.name)
-        raise requests.exceptions.HTTPError(url, None, err_message)
+        raise requests.exceptions.HTTPError(None, err_message, url)
 
     log.info('Downloaded ok - %s', printable_file_size(length))
     tmp_file.seek(0)

--- a/ckanext/qa/tasks.py
+++ b/ckanext/qa/tasks.py
@@ -608,7 +608,7 @@ def save_qa_result(resource, qa_result):
     import ckan.model as model
     from ckanext.qa.model import QA
 
-    now = datetime.datetime.now(tzinfo=pytz.utc)
+    now = datetime.datetime.now(tz=pytz.utc)
 
     qa = QA.get_for_resource(resource.id)
     if not qa:

--- a/ckanext/qa/tasks.py
+++ b/ckanext/qa/tasks.py
@@ -367,18 +367,15 @@ def score_by_sniffing_data(archival, resource, score_reasons):
     filepath = archival.cache_filepath
     delete_file = False
     if not os.path.exists(filepath):
-        log.debug("File not found on disk for resource %s", resource)
-        if resource.url_type == 'upload':
-            try:
-                resource_dict = toolkit.get_action('resource_show')(None, {'id': resource.id})
-                filepath = _download_url(resource_dict['url']).name
-                delete_file = True
-            except Exception as e:
-                score_reasons.append(_('A system error occurred during downloading this file') + '. %s' % e)
-                return (None, None)
-        else:
-            score_reasons.append(_('Cache filepath does not exist: "%s".') % filepath)
+        log.debug("%s not found on disk, retrieving from URL %s",
+                  filepath, archival.cache_url)
+        try:
+            filepath = _download_url(archival.cache_url).name
+            delete_file = True
+        except Exception as e:
+            score_reasons.append(_('A system error occurred during downloading this file') + '. %s' % e)
             return (None, None)
+
     if filepath:
         sniffed_format = sniff_file_format(filepath)
         if delete_file:

--- a/ckanext/qa/tasks.py
+++ b/ckanext/qa/tasks.py
@@ -377,12 +377,14 @@ def score_by_sniffing_data(archival, resource, score_reasons):
             return (None, None)
 
     if filepath:
-        sniffed_format = sniff_file_format(filepath)
-        if delete_file:
-            try:
-                os.remove(filepath)
-            except OSError as e:
-                log.warn("Unable to remove temporary file %s: %s", filepath, e)
+        try:
+            sniffed_format = sniff_file_format(filepath)
+        finally:
+            if delete_file:
+                try:
+                    os.remove(filepath)
+                except OSError as e:
+                    log.warn("Unable to remove temporary file %s: %s", filepath, e)
         score = lib.resource_format_scores().get(sniffed_format['format']) \
             if sniffed_format else None
         if sniffed_format:

--- a/ckanext/qa/tasks.py
+++ b/ckanext/qa/tasks.py
@@ -470,13 +470,12 @@ def _download_url(url):
 
 def get_response(url, headers):
     def get_url():
-        return requests.get(
-            url,
-            headers=headers,
-            timeout=DOWNLOAD_TIMEOUT,
-            verify=SSL_VERIFY,
-            stream=True,  # just gets the headers for now
-        )
+        kwargs = {'headers': headers, 'timeout': DOWNLOAD_TIMEOUT,
+                  'verify': SSL_VERIFY, 'stream': True} # just gets the headers for now
+        if 'ckan.download_proxy' in config:
+            proxy = config.get('ckan.download_proxy')
+            kwargs['proxies'] = {'http': proxy, 'https': proxy}
+        return requests.get(url, **kwargs)
     response = get_url()
     if response.status_code == 202:
         # Seen: https://data-cdfw.opendata.arcgis.com/datasets

--- a/ckanext/qa/tasks.py
+++ b/ckanext/qa/tasks.py
@@ -9,6 +9,8 @@ import os
 import tempfile
 import time
 import traceback
+
+import pytz
 import urlparse
 import routes
 
@@ -606,7 +608,7 @@ def save_qa_result(resource, qa_result):
     import ckan.model as model
     from ckanext.qa.model import QA
 
-    now = datetime.datetime.now()
+    now = datetime.datetime.now(tzinfo=pytz.utc)
 
     qa = QA.get_for_resource(resource.id)
     if not qa:

--- a/ckanext/qa/tests/fake_ckan.py
+++ b/ckanext/qa/tests/fake_ckan.py
@@ -10,12 +10,12 @@ TASK_STATUS_ARCHIVER_OK = json.dumps(
                     'last_success': '2008-10-01',
                     'first_failure': '',
                     'failure_count': 0,
-                    }),
+                }),
                 'stack': '',
                 'last_updated': '2008-10-10T19:30:37.536836',
                 }
      }
-    )
+)
 
 request_store = []
 task_status = {'archiver': TASK_STATUS_ARCHIVER_OK,

--- a/ckanext/qa/tests/mock_remote_server.py
+++ b/ckanext/qa/tests/mock_remote_server.py
@@ -7,6 +7,7 @@ from threading import Thread
 from time import sleep
 from wsgiref.simple_server import make_server
 import urllib2
+import six
 import socket
 
 
@@ -37,7 +38,7 @@ class MockHTTPServer(object):
         This uses context manager to make sure the server is stopped::
 
             >>> with MockTestServer().serve() as addr:
-            ...     print urllib2.urlopen('%s/?content=hello+world').read()
+            ...     print(urllib2.urlopen('%s/?content=hello+world').read())
             ...
             'hello world'
         """
@@ -80,8 +81,8 @@ class MockHTTPServer(object):
         called and its return value used.
         """
         modpath, var = varspec.split(':')
-        mod = reduce(getattr, modpath.split('.')[1:], __import__(modpath))
-        var = reduce(getattr, var.split('.'), mod)
+        mod = six.moves.reduce(getattr, modpath.split('.')[1:], __import__(modpath))
+        var = six.moves.reduce(getattr, var.split('.'), mod)
         try:
             return var()
         except TypeError:
@@ -116,7 +117,7 @@ class MockEchoTestServer(MockHTTPServer):
         else:
             content = request.str_params.get('content', '')
 
-        if isinstance(content, unicode):
+        if isinstance(content, six.string_types):
             raise TypeError("Expected raw byte string for content")
 
         headers = [

--- a/ckanext/qa/tests/mock_remote_server.py
+++ b/ckanext/qa/tests/mock_remote_server.py
@@ -97,7 +97,8 @@ class MockEchoTestServer(MockHTTPServer):
         a 500 error response: 'http://localhost/?status=500'
 
         a 200 OK response, returning the function's docstring:
-         'http://localhost/?status=200;content-type=text/plain;content_var=ckan.tests.lib.test_package_search:test_wsgi_app.__doc__'
+        'http://localhost/?status=200;content-type=text/plain;content_var
+        =ckan.tests.lib.test_package_search:test_wsgi_app.__doc__'
 
     To specify content, use:
 
@@ -114,10 +115,16 @@ class MockEchoTestServer(MockHTTPServer):
         if 'content_var' in request.str_params:
             content = request.str_params.get('content_var')
             content = self.get_content(content)
+        elif 'content_long' in request.str_params:
+            content = '*' * 1000001
         else:
             content = request.str_params.get('content', '')
+        if 'method' in request.str_params \
+                and request.method.lower() != request.str_params['method'].lower():
+            content = ''
+            status = 405
 
-        if isinstance(content, six.string_types):
+        if isinstance(content, six.text_type):
             raise TypeError("Expected raw byte string for content")
 
         headers = [
@@ -125,8 +132,11 @@ class MockEchoTestServer(MockHTTPServer):
             for item in request.str_params.items()
             if item[0] not in ('content', 'status')
         ]
-        if content:
-            headers += [('Content-Length', str(len(content)))]
+        if 'length' in request.str_params:
+            cl = request.str_params.get('length')
+            headers += [('Content-Length', cl)]
+        elif content and 'no-content-length' not in request.str_params:
+            headers += [('Content-Length', six.binary_type(len(content)))]
         start_response(
             '%d %s' % (status, responses[status]),
             headers

--- a/ckanext/qa/tests/test_link_checker.py
+++ b/ckanext/qa/tests/test_link_checker.py
@@ -121,12 +121,12 @@ class TestLinkChecker(ControllerTestCase):
         # accept, because browsers accept this
         # see discussion: http://trac.ckan.org/ticket/318
         result = self.check_link(url)
-        print result
+        print(result)
         assert_equal(result['url_errors'], [])
 
     @with_mock_url('?status=200 ')
     def test_trailing_whitespace(self, url):
         # accept, because browsers accept this
         result = self.check_link(url)
-        print result
+        print(result)
         assert_equal(result['url_errors'], [])

--- a/ckanext/qa/tests/test_sniff_format.py
+++ b/ckanext/qa/tests/test_sniff_format.py
@@ -51,7 +51,7 @@ class TestSniffFormat:
             if format_extension == format:
                 if not filename or filename in filepath:
                     cls.assert_file_has_format_sniffed_correctly(format_extension, filepath)
-                break
+                    break
         else:
             assert 0, format  # Could not find fixture for format
 

--- a/ckanext/qa/tests/test_sniff_format.py
+++ b/ckanext/qa/tests/test_sniff_format.py
@@ -292,5 +292,5 @@ def test_turtle_regex():
 
 def test_is_ttl__num_triples():
     triple = '<subject> <predicate> <object>; <predicate> <object>.'
-    assert not is_ttl('\n'.join([triple]*2))
-    assert is_ttl('\n'.join([triple]*5))
+    assert not is_ttl('\n'.join([triple] * 2))
+    assert is_ttl('\n'.join([triple] * 5))

--- a/ckanext/qa/tests/test_sniff_format.py
+++ b/ckanext/qa/tests/test_sniff_format.py
@@ -30,7 +30,7 @@ class TestSniffFormat:
         '''Given a filepath, checks the sniffed format matches the format_extension.'''
         expected_format = format_extension
         sniffed_format = sniff_file_format(filepath)
-        assert sniffed_format, expected_format
+        assert sniffed_format, "Expected {} but failed to sniff any format: {}".format(expected_format, sniffed_format)
         expected_format_without_zip = expected_format.replace('.zip', '')
         assert_equal(sniffed_format['format'].lower(), expected_format_without_zip)
 

--- a/ckanext/qa/tests/test_sniff_format.py
+++ b/ckanext/qa/tests/test_sniff_format.py
@@ -30,7 +30,7 @@ class TestSniffFormat:
         '''Given a filepath, checks the sniffed format matches the format_extension.'''
         expected_format = format_extension
         sniffed_format = sniff_file_format(filepath)
-        assert sniffed_format, "Expected {} but failed to sniff any format: {}".format(expected_format, sniffed_format)
+        assert sniffed_format, "Expected {} but failed to sniff any format for file: {}".format(expected_format, filepath)
         expected_format_without_zip = expected_format.replace('.zip', '')
         assert_equal(sniffed_format['format'].lower(), expected_format_without_zip)
 
@@ -49,16 +49,11 @@ class TestSniffFormat:
     def check_format(cls, format, filename=None):
         for format_extension, filepath in cls.fixture_files:
             if format_extension == format:
-                if filename:
-                    if filename in filepath:
-                        break
-                    else:
-                        continue
-                else:
-                    break
+                if not filename or filename in filepath:
+                    cls.assert_file_has_format_sniffed_correctly(format_extension, filepath)
+                break
         else:
             assert 0, format  # Could not find fixture for format
-        cls.assert_file_has_format_sniffed_correctly(format_extension, filepath)
 
     def test_xls(self):
         self.check_format('xls', '10-p108-data-results')

--- a/ckanext/qa/tests/test_tasks.py
+++ b/ckanext/qa/tests/test_tasks.py
@@ -78,7 +78,7 @@ class TestTask(BaseCase):
         context = {'model': model, 'ignore_auth': True, 'session': model.Session, 'user': 'test'}
         pkg = {'name': 'testpkg', 'license_id': 'uk-ogl', 'resources': [
             {'url': 'http://test.com/', 'format': 'CSV', 'description': 'Test'}
-            ]}
+        ]}
         pkg = get_action('package_create')(context, pkg)
         resource_dict = pkg['resources'][0]
         res_id = resource_dict['id']
@@ -304,7 +304,7 @@ class TestSaveQaResult(object):
             'openness_score_reason': 'Detected as CSV which scores 3',
             'format': 'CSV',
             'archival_timestamp': datetime.datetime(2015, 12, 16),
-            }
+        }
         qa_result.update(kwargs)
         return qa_result
 
@@ -335,7 +335,7 @@ class TestUpdatePackage(object):
             'url': 'http://example.com/file.csv',
             'title': 'Some data',
             'format': '',
-            }
+        }
         dataset = ckan_factories.Dataset(resources=[resource])
         resource = model.Resource.get(dataset['resources'][0]['id'])
 
@@ -359,7 +359,7 @@ class TestUpdateResource(object):
             'url': 'http://example.com/file.csv',
             'title': 'Some data',
             'format': '',
-            }
+        }
         dataset = ckan_factories.Dataset(resources=[resource])
         resource = model.Resource.get(dataset['resources'][0]['id'])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,10 @@
-xlrd==1.0.0
-python-magic==0.4.12
+xlrd==1.1.0
+#python-magic==0.4.15 #in ckancore
 messytables==0.15.2
 progressbar==2.3
+#SQLAlchemy>=0.6.6 #in ckancore
+#requests==2.11.1 #in ckancore
+six>=1.0.0 #in ckancore
+
+ckanext-archiver
+ckanext-report

--- a/setup.py
+++ b/setup.py
@@ -17,20 +17,16 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'ckanext-archiver>=2.0',
-        'ckanext-report',
-        'SQLAlchemy>=0.6.6',
-        'requests',
-        'xlrd>=0.8.0',
-        'messytables>=0.8',
-        'python-magic>=0.4',
-        'progressbar',
-        'six>=1.9' # until messytables->html5lib releases https://github.com/html5lib/html5lib-python/pull/301
+      # CKAN extensions should not list dependencies here, but in a separate
+      # ``requirements.txt`` file.
+      #
+      # http://docs.ckan.org/en/latest/extensions/best-practices.html#add-third-party-libraries-to-requirements-txt
     ],
     tests_require=[
-        'nose',
-        'mock',
-        'flask'
+      # CKAN extensions should not list dependencies here, but in a separate
+      # ``dev-requirements.txt`` file.
+      #
+      # http://docs.ckan.org/en/latest/extensions/best-practices.html#add-third-party-libraries-to-requirements-txt
     ],
     entry_points='''
     [paste.paster_command]


### PR DESCRIPTION
- Download archive to a temporary file if not already on disk, so we can do type sniffing. This is relevant when the file uploader goes to somewhere remote like S3.
- Use UTC timestamps internally so that times are stored correctly. They're stored in the database without timezone info, so if they were originally generated with a timezone, they'll come out wrong.
- Enable file downloads to optionally go through a proxy.
- Use BSD `file` fallback more consistently when other methods fail.
- Clean up for Flake8 and Python 3.
- Move dependencies into external `requirements.txt` instead of `setup.py`.