### PR TITLE
Determine XML variant for mimetype 'text/xml'

### DIFF
--- a/ckanext/qa/sniff_format.py
+++ b/ckanext/qa/sniff_format.py
@@ -38,7 +38,7 @@ def sniff_file_format(filepath):
     mime_type = magic.from_file(filepath_utf8, mime=True)
     log.info('Magic detects file as: %s', mime_type)
     if mime_type:
-        if mime_type == 'application/xml':
+        if mime_type in ('application/xml', 'text/xml'):
             with open(filepath) as f:
                 buf = f.read(5000)
             format_ = get_xml_variant_including_xml_declaration(buf)


### PR DESCRIPTION
With mime sniffing, the XML variant is currently only determined for the mimetype *application/xml*.

RFC3023 also describes the mimetype *text/xml*, as well as other more exotic types.

> If an XML document -- that is, the unprocessed, source XML document -- is readable by casual users, text/xml is preferable to application/xml.  MIME user agents (and web user agents) that do not have explicit support for text/xml will treat it as text/plain, for example, by displaying the XML MIME entity as plain text. Application/xml is preferable when the XML MIME entity is unreadable by casual users.

The determination is handled by [python-magic](https://pypi.org/project/python-magic/), which is a wrapper fo the libmagic library. 

As far as I've tested, the determination seems to be platform dependent (I guess based on the platform's mime type database and package version). For example, on a default Ubuntu 16.04 server, the mime type reported by libmagic for *.xml* files is *application/xml*, while on Ubuntu 20.04 *text/xml* is reported.

The merge request contains simple changes so that the call to `get_xml_variant_including_xml_declaration()` is performed for both mimetypes mentioned above.